### PR TITLE
Add delay to replaying blocks, reformat serialized tracker output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2860,7 +2860,7 @@ dependencies = [
 
 [[package]]
 name = "sothis"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "clap",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sothis"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 authors = ["makemake <vukasin@gostovic.me>"]
 license = "GPL-3.0-or-later"

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Options:
           Time in ms to check for new blocks. [default: 500]
       --entropy_threshold <entropy_threshold>...
           Set the percentage of failed transactions to trigger a warning [default: 0.07]
+  -d, --replay_delay <replay_delay>...
+          Default delay for block replay in ms [default: 0]
       --send_as_raw [<send_as_raw>...]
           Exit the program if a transaction fails
   -c, --contract_address <contract_address>...
@@ -86,6 +88,7 @@ The tracking mode is used to track the change in value of a storage slot for a c
 The result is saved to a JSON file that looks like this:
 ```json
 {
+  "address":"0x1c479675ad559DC151F6Ec7ed3FbF8ceE79582B6",
 	"storage_slot":"0x0",
 	"state_changes":[
 		{"block_number":"0x10b7bbc","value":"0x00000000000000000000000000000000000000000000000000000000000e2b18"}

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,6 @@ pub struct AppConfig {
     exit_on_tx_fail: bool,
     send_as_raw: bool,
     entropy_threshold: f32,
-    replay_delay: u64,
     block_listen_time: u64,
     path: String,
     filename: String,
@@ -74,12 +73,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .num_args(1..)
             .default_value("0.07")
             .help("Set the percentage of failed transactions to trigger a warning"))
-        .arg(Arg::new("replay_delay")
-            .long("replay_delay")
-            .short('d')
-            .num_args(1..)
-            .default_value("0")
-            .help("Default delay for block replay in ms"))
         .arg(Arg::new("send_as_raw")
             .long("send_as_raw")
             .num_args(0..)
@@ -119,7 +112,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         app_config.exit_on_tx_fail = matches.get_occurrences::<String>("exit_on_tx_fail").is_some();
         app_config.send_as_raw = matches.get_occurrences::<String>("send_as_raw").is_some();
         app_config.entropy_threshold = matches.get_one::<String>("entropy_threshold").expect("required").parse::<f32>()?;
-        app_config.replay_delay = matches.get_one::<String>("replay_delay").expect("required").parse::<u64>()?;
         app_config.block_listen_time = matches.get_one::<String>("block_listen_time").expect("required").parse::<u64>()?;
         app_config.path = matches.get_one::<String>("path").expect("required").to_string();
         app_config.filename = matches.get_one::<String>("filename").expect("required").to_string();

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ lazy_static! {
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let matches = Command::new("sothis")
-        .version("0.3.0")
+        .version("0.3.1")
         .author("makemake <vukasin@gostovic.me>")
         .about("Tool for replaying historical transactions. Designed to be used with anvil or hardhat.")
         .arg(Arg::new("source_rpc")

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ pub struct AppConfig {
     exit_on_tx_fail: bool,
     send_as_raw: bool,
     entropy_threshold: f32,
+    replay_delay: u64,
     block_listen_time: u64,
     path: String,
     filename: String,
@@ -73,6 +74,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .num_args(1..)
             .default_value("0.07")
             .help("Set the percentage of failed transactions to trigger a warning"))
+        .arg(Arg::new("replay_delay")
+            .long("replay_delay")
+            .short('d')
+            .num_args(1..)
+            .default_value("0")
+            .help("Default delay for block replay in ms"))
         .arg(Arg::new("send_as_raw")
             .long("send_as_raw")
             .num_args(0..)
@@ -112,6 +119,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         app_config.exit_on_tx_fail = matches.get_occurrences::<String>("exit_on_tx_fail").is_some();
         app_config.send_as_raw = matches.get_occurrences::<String>("send_as_raw").is_some();
         app_config.entropy_threshold = matches.get_one::<String>("entropy_threshold").expect("required").parse::<f32>()?;
+        app_config.replay_delay = matches.get_one::<String>("replay_delay").expect("required").parse::<u64>()?;
         app_config.block_listen_time = matches.get_one::<String>("block_listen_time").expect("required").parse::<u64>()?;
         app_config.path = matches.get_one::<String>("path").expect("required").to_string();
         app_config.filename = matches.get_one::<String>("filename").expect("required").to_string();

--- a/src/replay/replay.rs
+++ b/src/replay/replay.rs
@@ -1,3 +1,6 @@
+use std::thread::sleep;
+use tokio::time::Duration;
+
 use crate::APP_CONFIG;
 use crate::replay::send_transaction::send_transactions;
 use crate::RpcConnection;
@@ -37,7 +40,14 @@ pub async fn replay_historic_blocks(
     // set insanely high interval for the blocks
     replay_rpc.evm_set_interval_mining(std::u32::MAX.into()).await?;
 
-    while until > replay_block {
+    // Get the time we're delaying the replay for
+    let replay_delay;
+    {
+        let app_config = APP_CONFIG.lock()?;
+        replay_delay = app_config.replay_delay;
+    }
+
+    loop {
         // we write a bit of illegible code
         let hex_block = decimal_to_hex(replay_block + 1);
         // get block from historical node
@@ -60,6 +70,10 @@ pub async fn replay_historic_blocks(
         println!("Successfully replayed block {}", hex_to_decimal(&hex_block)?);
 
         replay_block = hex_to_decimal(&replay_rpc.block_number().await?)?;
+        if until < replay_block {
+            break;
+        }
+        sleep(Duration::from_millis(replay_delay))
     }
     println!("Done replaying blocks");
     Ok(())

--- a/src/tracker/tracker.rs
+++ b/src/tracker/tracker.rs
@@ -25,6 +25,7 @@ pub async fn track_state(
     })?;
 
 	let mut storage = StateChangeList {
+		address: contract_address.clone(),
 		storage_slot: storage_slot,
 		state_changes: Vec::new(),
 	};

--- a/src/tracker/types.rs
+++ b/src/tracker/types.rs
@@ -1,7 +1,6 @@
 use serde::{Deserialize, Serialize};
 use ethers::types::U256;
 
-// 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub struct StateChange {
 	pub block_number: U256,
@@ -19,6 +18,7 @@ impl Default for StateChange {
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct StateChangeList {
-	pub storage_slot: U256,
+    pub address: String,
+    pub storage_slot: U256,
 	pub state_changes: Vec<StateChange>,
 }


### PR DESCRIPTION
Adds an optional delay to replaying blocks, as well as adding the contract address in the serialized output of the tracking mode. The output JSON looks like this now:
```json
{
"address":"0x1c479675ad559DC151F6Ec7ed3FbF8ceE79582B6",
"storage_slot":"0x0",
"state_changes: [{"block_number":"0x10c0201","value":"0x00000000000000000000000000000000000000000000000000000000000e517f"}]
}
```